### PR TITLE
Remove `experimentalCodeSplitting` option

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,5 @@ export default {
       format: "system",
       sourcemap: true
     }
-  ],
-  experimentalCodeSplitting: true
+  ]
 };


### PR DESCRIPTION
`experimentalCodeSplitting` has been removed in rollup v1.